### PR TITLE
style: adjust time multiplier in wireframe example

### DIFF
--- a/examples/src/wireframe.js
+++ b/examples/src/wireframe.js
@@ -83,7 +83,7 @@ async function initScene(overlay, mapContainer) {
 
     line.material.resolution.copy(overlay.getViewportSize());
     line.material.color.setHSL(
-      ((time * 0.36) / COLOR_CHANGE_DURATION) % 1,
+      ((time * 0.001) / COLOR_CHANGE_DURATION) % 1,
       0.69,
       0.5
     );


### PR DESCRIPTION
previous range was [0, 360] and then [0, 1], but still used the old time multiplier, so the animation was going wild