### PR TITLE
refactor(overlay): update webgloverlayview types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ThreejsOverlayView for Google Maps
 
-A wrapper for `google.maps.WebglOverlayView` that takes care of the
+WebGLOverlayView
+A wrapper for `google.maps.` that takes care of the
 integration between three.js and the Google Maps JavaScript API. It lets
 you create Google Maps overlays directly with three.js.
 
@@ -9,7 +10,7 @@ you create Google Maps overlays directly with three.js.
 </div>
 
 We recommend that you first make yourself familiar with
-[the official documentation][docs] for the WebglOverlayView. The rest of the
+[the official documentation][docs] for the WebGLOverlayView. The rest of the
 documentation will assume that you know how to load the Google Maps API and
 how to configure and create the map.
 
@@ -34,10 +35,10 @@ We provide a set of examples to quickly get you going. Those can be found in
 [`./examples`](./examples). They are also hosted on
 [GitHub Pages](https://ubilabs.github.io/threejs-overlay-view):
 
-* [Simple Cube](https://ubilabs.github.io/threejs-overlay-view/cube.html)
-* [Wireframe Building](https://ubilabs.github.io/threejs-overlay-view/wireframe.html)
-* [Animated Car](https://ubilabs.github.io/threejs-overlay-view/car.html)
-* [Video Texture](https://ubilabs.github.io/threejs-overlay-view/video.html)
+- [Simple Cube](https://ubilabs.github.io/threejs-overlay-view/cube.html)
+- [Wireframe Building](https://ubilabs.github.io/threejs-overlay-view/wireframe.html)
+- [Animated Car](https://ubilabs.github.io/threejs-overlay-view/car.html)
+- [Video Texture](https://ubilabs.github.io/threejs-overlay-view/video.html)
 
 ## Usage
 
@@ -136,7 +137,7 @@ in your scene) depending on the current map-viewport using
 
 ### Lifecycle Hooks and Animations
 
-Similar to the `WebglOverlayView`, the `ThreejsOverlayView` also provides a
+Similar to the `WebGLOverlayView`, the `ThreejsOverlayView` also provides a
 set of lifecycle hooks that you can define to react to certain events in
 the overlays' lifecycle. There are three of them - all optional: `onAdd`,
 `update`, and `onRemove`. They all are called without any parameters and

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # ThreejsOverlayView for Google Maps
 
-WebGLOverlayView
-A wrapper for `google.maps.` that takes care of the
+A wrapper for `google.maps.WebGLOverlayView` that takes care of the
 integration between three.js and the Google Maps JavaScript API. It lets
 you create Google Maps overlays directly with three.js.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "./examples"
       ],
       "devDependencies": {
-        "@types/google.maps": "^3.44.5",
+        "@types/google.maps": "^3.47.3",
         "@types/three": "^0.128.0",
         "microbundle": "^0.13.0",
         "prettier": "^2.3.0",
@@ -3060,9 +3060,10 @@
       "license": "MIT"
     },
     "node_modules/@types/google.maps": {
-      "version": "3.44.6",
-      "dev": true,
-      "license": "MIT"
+      "version": "3.47.3",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.47.3.tgz",
+      "integrity": "sha512-BF/BzpO0LWiwR/bBoGVriy7e2n+syuGNQMQ0r/+GtisUcgKn9P7Z4rmLNmZko9niE8JJ5dpMkxHeen7gADlNaw==",
+      "dev": true
     },
     "node_modules/@types/http-proxy": {
       "version": "1.17.6",
@@ -15059,7 +15060,9 @@
       "dev": true
     },
     "@types/google.maps": {
-      "version": "3.44.6",
+      "version": "3.47.3",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.47.3.tgz",
+      "integrity": "sha512-BF/BzpO0LWiwR/bBoGVriy7e2n+syuGNQMQ0r/+GtisUcgKn9P7Z4rmLNmZko9niE8JJ5dpMkxHeen7gADlNaw==",
       "dev": true
     },
     "@types/http-proxy": {
@@ -15095,7 +15098,7 @@
     "@ubilabs/threejs-overlay-view": {
       "version": "file:",
       "requires": {
-        "@types/google.maps": "^3.44.5",
+        "@types/google.maps": "3.47.3",
         "@types/three": "^0.128.0",
         "@ubilabs/threejs-overlay-view-examples": "file:examples",
         "microbundle": "^0.13.0",
@@ -17117,7 +17120,9 @@
           "dev": true
         },
         "@types/google.maps": {
-          "version": "3.44.6",
+          "version": "3.47.3",
+          "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.47.3.tgz",
+          "integrity": "sha512-BF/BzpO0LWiwR/bBoGVriy7e2n+syuGNQMQ0r/+GtisUcgKn9P7Z4rmLNmZko9niE8JJ5dpMkxHeen7gADlNaw==",
           "dev": true
         },
         "@types/http-proxy": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ubilabs/threejs-overlay-view",
   "version": "0.6.1",
-  "description": "A wrapper for the Google Maps WebglOverlayView that takes care of the integration between three.js and the Google Maps JavaScript API. It lets you create a Google Maps overlays directly with three.js.",
+  "description": "A wrapper for the Google Maps WebGLOverlayView that takes care of the integration between three.js and the Google Maps JavaScript API. It lets you create a Google Maps overlays directly with three.js.",
   "keywords": [
     "google maps",
     "maps",
@@ -45,7 +45,7 @@
     "three": ">=0.125.0"
   },
   "devDependencies": {
-    "@types/google.maps": "^3.44.5",
+    "@types/google.maps": "^3.47.3",
     "@types/three": "^0.128.0",
     "microbundle": "^0.13.0",
     "prettier": "^2.3.0",

--- a/src/threejs-overlay-view.ts
+++ b/src/threejs-overlay-view.ts
@@ -19,16 +19,16 @@ import type {LatLngAltitudeLiteral, RaycastOptions} from './types';
 const projectionMatrixInverse = new Matrix4();
 
 /**
- * A wrapper for google.maps.WebglOverlayView handling the details of the
+ * A wrapper for google.maps.WebGLOverlayView handling the details of the
  * integration with three.js.
  */
 export default class ThreeJSOverlayView {
   /**
-   * The WebglOverlayView instance being used. Aggregation is used instead
+   * The WebGLOverlayView instance being used. Aggregation is used instead
    * of extending the class to allow for this class to be parsed before the
    * google-maps API has been loaded.
    */
-  protected readonly overlay: google.maps.WebglOverlayView;
+  protected readonly overlay: google.maps.WebGLOverlayView;
 
   /**
    * The three.js camera-instance. When interacting with this camera it is
@@ -88,7 +88,7 @@ export default class ThreeJSOverlayView {
     referencePoint: LatLngAltitudeLiteral | google.maps.LatLngLiteral
   ) {
     this.referencePoint = {altitude: 0, ...referencePoint};
-    this.overlay = this.initWebglOverlayView();
+    this.overlay = this.initWebGLOverlayView();
     this.renderer = null;
     this.scene = this.initScene();
     this.camera = new PerspectiveCamera();
@@ -231,7 +231,8 @@ export default class ThreeJSOverlayView {
    * Initializes the threejs-renderer when the rendering-context becomes available.
    * @param gl
    */
-  protected onContextRestored(gl: WebGLRenderingContext) {
+  protected onContextRestored(stateOptions: google.maps.WebGLStateOptions) {
+    const {gl} = stateOptions;
     const mapGlCanvas = gl.canvas as HTMLCanvasElement;
 
     let renderer = new WebGL1Renderer({
@@ -267,10 +268,10 @@ export default class ThreeJSOverlayView {
    * @param gl
    * @param transformer
    */
-  protected onDraw(
-    gl: WebGLRenderingContext,
-    transformer: google.maps.CoordinateTransformer
-  ) {
+
+  protected onDraw(drawOptions: google.maps.WebGLDrawOptions) {
+    const {gl, transformer} = drawOptions;
+
     if (!this.scene || !this.renderer) {
       return;
     }
@@ -324,9 +325,9 @@ export default class ThreeJSOverlayView {
   }
 
   /**
-   * Creates the google.maps.WebglOverlayView instance
+   * Creates the google.maps.WebGLOverlayView instance
    */
-  protected initWebglOverlayView(): google.maps.WebglOverlayView {
+  protected initWebGLOverlayView(): google.maps.WebGLOverlayView {
     if (!google || !google.maps) {
       throw new Error(
         'Google Maps API not loaded. Please make sure to create the ' +
@@ -334,14 +335,14 @@ export default class ThreeJSOverlayView {
       );
     }
 
-    if (!google.maps.WebglOverlayView) {
+    if (!google.maps.WebGLOverlayView) {
       throw new Error(
-        'WebglOverlayView not found. Please make sure to load the ' +
+        'WebGLOverlayView not found. Please make sure to load the ' +
           'beta-channel of the Google Maps API.'
       );
     }
 
-    const overlay = new google.maps.WebglOverlayView();
+    const overlay = new google.maps.WebGLOverlayView();
 
     overlay.onAdd = wrapExceptionLogger(() => {
       if (this.onAdd === null) return;


### PR DESCRIPTION
There were three changes in the API that I noticed. The new options parameter contain the parameter of the old method functions (and nothing besides that):

1)
`WebglOverlayView` --> `WebGLOverlayView`

--------------------
2)
```
protected onDraw(
    gl: WebGLRenderingContext,
    transformer: google.maps.CoordinateTransformer
)
```
-->
`protected onDraw(drawOptions: google.maps.WebGLDrawOptions)`

--------------------
3)
`protected onContextRestored(gl: WebGLRenderingContext)`
-->
`protected onContextRestored(stateOptions: google.maps.WebGLStateOptions)`